### PR TITLE
Fix typo in Attestations & Reputation section

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,7 +261,7 @@
             <p>
               Attestations are the backbone of trust and basis of reputation in decentralized
               identity systems. Attestations between groups of individuals and businesses
-              are use to make important decisions in personal and business life.
+              are used to make important decisions in personal and business life.
               To address this area of identity, DIF intends to equip the decentralized
               identity community with the protocols, tools, and implementations
               necessary to create and validate identity attestations.


### PR DESCRIPTION
This fixes a minor typo in the Attestations & Reputation section. I wasn't sure how to rebase [a PR I made through GH](https://github.com/decentralized-identity/decentralized-identity.github.io/pull/2) so I redid the change here. Cheers!