### PR TITLE
Rename IND WG -> ID WG

### DIFF
--- a/index.html
+++ b/index.html
@@ -308,7 +308,7 @@
                   <a class="nav-link" href="/#wgs">Working Groups</a>
                   <!-- <ul class="sub-menu">
                     <li>
-                      <a href="/working-groups/identifiers-names-discovery.html">Identifiers, Names, and Discovery</a>
+                      <a href="/working-groups/identifiers-discovery.html">Identifiers and Discovery</a>
                     </li>
                     <li>
                       <a href="/working-groups/storage-compute.html">Storage and Compute</a>
@@ -432,9 +432,9 @@
           </div> <!-- col -->
           <div class="col-md-7 sm-m-30px-b">
             <div class="feature-box-03">
-              <h4 class="font-alt">Identifiers, Names, and Discovery</h4>
+              <h4 class="font-alt">Identifiers and Discovery</h4>
               <p>A key piece of the decentralized identity equation is how people, organizations, and devices can be identified and located without centralized systems of identifiers (e.g. email addresses). DIF members are actively working on protocols and implementations that enable creation, resolution, and discovery of decentralized identifiers and names across decentralized systems, like blockchains and distributed ledgers.</p>
-              <a href="/working-groups/identifiers-names-discovery.html" class="m-btn m-btn-t-dark">Learn More</a>
+              <a href="/working-groups/identifiers-discovery.html" class="m-btn m-btn-t-dark">Learn More</a>
             </div>
           </div> <!-- col -->
           

--- a/working-groups/authentication.html
+++ b/working-groups/authentication.html
@@ -308,7 +308,7 @@
                   <a class="nav-link" href="/#wgs">Working Groups</a>
                   <!-- <ul class="sub-menu">
                     <li>
-                      <a href="/working-groups/identifiers-names-discovery.html">Identifiers, Names, and Discovery</a>
+                      <a href="/working-groups/identifiers-discovery.html">Identifiers and Discovery</a>
                     </li>
                     <li>
                       <a href="/working-groups/storage-compute.html">Storage and Compute</a>

--- a/working-groups/claims-credentials.html
+++ b/working-groups/claims-credentials.html
@@ -308,7 +308,7 @@
                   <a class="nav-link" href="/#wgs">Working Groups</a>
                   <!-- <ul class="sub-menu">
                     <li>
-                      <a href="/working-groups/identifiers-names-discovery.html">Identifiers, Names, and Discovery</a>
+                      <a href="/working-groups/identifiers-discovery.html">Identifiers and Discovery</a>
                     </li>
                     <li>
                       <a href="/working-groups/storage-compute.html">Storage and Compute</a>

--- a/working-groups/identifiers-discovery.html
+++ b/working-groups/identifiers-discovery.html
@@ -308,7 +308,7 @@
                   <a class="nav-link" href="/#wgs">Working Groups</a>
                   <!-- <ul class="sub-menu">
                     <li>
-                      <a href="/working-groups/identifiers-names-discovery.html">Identifiers, Names, and Discovery</a>
+                      <a href="/working-groups/identifiers-discovery.html">Identifiers and Discovery</a>
                     </li>
                     <li>
                       <a href="/working-groups/storage-compute.html">Storage and Compute</a>

--- a/working-groups/storage-compute.html
+++ b/working-groups/storage-compute.html
@@ -308,7 +308,7 @@
                   <a class="nav-link" href="/#wgs">Working Groups</a>
                   <!-- <ul class="sub-menu">
                     <li>
-                      <a href="/working-groups/identifiers-names-discovery.html">Identifiers, Names, and Discovery</a>
+                      <a href="/working-groups/identifiers-discovery.html">Identifiers and Discovery</a>
                     </li>
                     <li>
                       <a href="/working-groups/storage-compute.html">Storage and Compute</a>


### PR DESCRIPTION
This updates a few pages to correctly say "Identifiers and Discovery" instead of "Identifiers, Names, and Discovery".