### PR TITLE
Fix broken link to SIOP repo

### DIFF
--- a/working-groups/authentication.html
+++ b/working-groups/authentication.html
@@ -389,7 +389,9 @@
                   <p>This specification defines the SIOP DID AuthN flavor to use OpenID Connect (OIDC) together with the strong decentralization, privacy and security guarantees of DID for everyone who wants to have a generic way to integrate SSI wallets into their web applications.</p>
                   
                     
-                      <a class="block-link icon-link" href="https://github.com/decentralized-identity/papers/blob/master/did-authn/siop/did-authn-siop-profile.md">Explainer</a>                    
+                      <a class="block-link icon-link" href="https://github.com/decentralized-identity/papers/blob/master/did-authn/siop/did-authn-siop-profile.md">Explainer</a>
+			
+                      <a class="block-link icon-link" href="https://github.com/decentralized-identity/did-siop">Repo</a>
                   
                 </dd>
               

--- a/working-groups/authentication.html
+++ b/working-groups/authentication.html
@@ -389,10 +389,7 @@
                   <p>This specification defines the SIOP DID AuthN flavor to use OpenID Connect (OIDC) together with the strong decentralization, privacy and security guarantees of DID for everyone who wants to have a generic way to integrate SSI wallets into their web applications.</p>
                   
                     
-                      <a class="block-link icon-link" href="https://github.com/decentralized-identity/papers/blob/master/did-authn/siop/did-authn-siop-profile.md">Explainer</a>
-                    
-                      <a class="block-link icon-link" href="https://github.com/decentralized-identity/credential-manifest">Repo</a>
-                    
+                      <a class="block-link icon-link" href="https://github.com/decentralized-identity/papers/blob/master/did-authn/siop/did-authn-siop-profile.md">Explainer</a>                    
                   
                 </dd>
               


### PR DESCRIPTION
The repo link was pointing to "credential-manifest" instead of SIOP; a likely copy/paste error.

~~(If there's a SIOP repo, then updating the link rather than deleting it would be the right fix -- but I didn't manage to find it.)~~ Found it ;-)