### PR TITLE
Add links to Confidential Storage spec on secure data storage wg page

### DIFF
--- a/docs/working-groups/secure-data-storage.html
+++ b/docs/working-groups/secure-data-storage.html
@@ -256,9 +256,15 @@ minimum viable HTTP-based interface compatible with W3C DIDs/VCs.</p>
                   
                 </dd>
               
-                <dt>Secure Data Storage v0.9 - Data Model, Representations, and HTTP API</dt>
+                <dt>Confidential Storage 0.1</dt>
                 <dd>
-                  <p>[NORMATIVE]</p>
+                  <p>This specification describes a privacy-respecting mechanism for storing, indexing, and retrieving encrypted data at a storage provider. It is often useful when an individual or organization wants to protect data in a way that the storage provider cannot view, analyze, aggregate, or resell the data. This approach also ensures that application data is portable and protected from storage provider data breaches.</p>
+                  
+                    
+                      <a class="block-link icon-link" href="https://identity.foundation/confidential-storage/">Specification</a>
+                    
+                      <a class="block-link icon-link" href="https://github.com/decentralized-identity/confidential-storage">Repo</a>
+                    
                   
                 </dd>
               

--- a/docs/working-groups/secure-data-storage.html
+++ b/docs/working-groups/secure-data-storage.html
@@ -256,14 +256,14 @@ minimum viable HTTP-based interface compatible with W3C DIDs/VCs.</p>
                   
                 </dd>
               
-                <dt>Confidential Storage 0.1</dt>
+                <dt>Encrypted Data Vaults</dt>
                 <dd>
                   <p>This specification describes a privacy-respecting mechanism for storing, indexing, and retrieving encrypted data at a storage provider. It is often useful when an individual or organization wants to protect data in a way that the storage provider cannot view, analyze, aggregate, or resell the data. This approach also ensures that application data is portable and protected from storage provider data breaches.</p>
                   
                     
-                      <a class="block-link icon-link" href="https://identity.foundation/confidential-storage/">Specification</a>
+                      <a class="block-link icon-link" href="https://identity.foundation/edv-spec/">Specification</a>
                     
-                      <a class="block-link icon-link" href="https://github.com/decentralized-identity/confidential-storage">Repo</a>
+                      <a class="block-link icon-link" href="https://github.com/decentralized-identity/edv-spec/">Repo</a>
                     
                   
                 </dd>

--- a/templates/pages/working-groups/secure-data-storage.html
+++ b/templates/pages/working-groups/secure-data-storage.html
@@ -60,8 +60,18 @@ minimum viable HTTP-based interface compatible with W3C DIDs/VCs." %}
         }
       ]
     }, 
-    "Secure Data Storage v0.9 - Data Model, Representations, and HTTP API": {
-      desc: "[NORMATIVE]"
+    "Confidential Storage 0.1": {
+      desc: "This specification describes a privacy-respecting mechanism for storing, indexing, and retrieving encrypted data at a storage provider. It is often useful when an individual or organization wants to protect data in a way that the storage provider cannot view, analyze, aggregate, or resell the data. This approach also ensures that application data is portable and protected from storage provider data breaches.",
+      links: [
+        {
+          text: "Specification",
+          href: "https://identity.foundation/confidential-storage/"
+        },
+        {
+          text: "Repo",
+          href: "https://github.com/decentralized-identity/confidential-storage"
+        }
+      ]
     },
     "Secure Data Storage Test Suite ": {
       desc: "[INFORMATIVE]"

--- a/templates/pages/working-groups/secure-data-storage.html
+++ b/templates/pages/working-groups/secure-data-storage.html
@@ -60,16 +60,16 @@ minimum viable HTTP-based interface compatible with W3C DIDs/VCs." %}
         }
       ]
     }, 
-    "Confidential Storage 0.1": {
+    "Encrypted Data Vaults": {
       desc: "This specification describes a privacy-respecting mechanism for storing, indexing, and retrieving encrypted data at a storage provider. It is often useful when an individual or organization wants to protect data in a way that the storage provider cannot view, analyze, aggregate, or resell the data. This approach also ensures that application data is portable and protected from storage provider data breaches.",
       links: [
         {
           text: "Specification",
-          href: "https://identity.foundation/confidential-storage/"
+          href: "https://identity.foundation/edv-spec/"
         },
         {
           text: "Repo",
-          href: "https://github.com/decentralized-identity/confidential-storage"
+          href: "https://github.com/decentralized-identity/edv-spec/"
         }
       ]
     },


### PR DESCRIPTION
Motivation:
* today i went to the secure data storage wg site to get a link to this spec but I was surprised that only the dwn spec was linked to, and the confidential storage spec was not even a hyperlink.