### PR TITLE
update all 3 links from WG homepage

### DIFF
--- a/config/working-groups.js
+++ b/config/working-groups.js
@@ -429,16 +429,16 @@ module.exports = {
             {
               text: "Specification",
               type: "doc",
-              href: "https://identity.foundation/specs/did-configuration/",
+              href: "https://identity.foundation/well-known-did-configuration/",
             },
             {
               text: "Main Repo",
-              href: "https://github.com/decentralized-identity/.well-known/",
+              href: "https://github.com/decentralized-identity/well-known-did-configuration",
             },
             {
               text: "Demo Web App",
               type: "app",
-              href: "https://identity.foundation/.well-known/resources/did-configuration/demo/build/index.html",
+              href: "https://identity.foundation/.well-known/did-configuration.json",
             },
           ],
         },


### PR DESCRIPTION
- i'm not sure what "demo web app" this used to link to?
- for some reason, the specification landing page links to the rendered respec HTML which, separately, is broken for some mysterious reason on the nunjucks page, which redirects to the homepage when you try loading it (whether `.../` or `.../index.html`)